### PR TITLE
[fix] own the reader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ impl BedReaderType<File> {
 
 /// A reader for BED files, supporting plain text, BGZF compression, and tabix indexing.
 pub struct BedReader {
-    reader: Option<BedReaderType<File>>,
+    reader: BedReaderType<File>,
     index: BedIndex,
 }
 
@@ -246,7 +246,7 @@ impl BedReader {
         };
 
         Ok(BedReader {
-            reader: Some(reader),
+            reader: reader,
             index,
         })
     }
@@ -254,7 +254,7 @@ impl BedReader {
     /// Reads a single `BedRecord` from the reader.
     pub fn read_record(&mut self) -> Result<Option<BedRecord>, BedError> {
         let mut line = String::new();
-        let bytes_read = self.reader.as_mut().unwrap().read_line(&mut line)?;
+        let bytes_read = self.reader.read_line(&mut line)?;
         if bytes_read == 0 {
             return Ok(None); // EOF
         }
@@ -370,13 +370,7 @@ impl BedReader {
         // Get chunks that overlap this region
         let qchunks = self.index.query(tid, &region);
 
-        // This is a dirty hack. Since noodles bgzf BufRead and Seek are only implemented on
-        // an owned Reader, by wrapping the reader in an Option, we can temporarily take ownership of
-        // it, and then put it back when we are done with it. Noodles should implement it's traits
-        // on both the owned and &mut refs of Reader.
-        let mut reader = self.reader.take().unwrap();
-
-        let ret = match (qchunks, reader) {
+        let ret = match (qchunks, self.reader) {
             (Some(Ok(chunks)), BedReaderType::Bgzf(mut reader)) => {
                 let q = csi::io::Query::new(&mut reader, chunks);
                 let header = self.index.header().expect("No header found");
@@ -385,7 +379,6 @@ impl BedReader {
             }
             _ => unimplemented!(),
         };
-        self.reader = Some(reader);
         ret
     }
 }


### PR DESCRIPTION
The issue is that noodles needs to implement `BufRead` and `Seek` on `&mut Reader` and not just `Reader` .

Example from std lib:
They have this: https://doc.rust-lang.org/src/std/io/buffered/bufreader.rs.html#448-456
They need this: https://doc.rust-lang.org/src/std/io/impls.rs.html#98-118

To get an owned Reader you can wrap your structs reader in an `Option` and then call `.take` to temporarily own it, then put it back when you are done with it.

LMK if you end up making a PR to Noodles for this, or if you don't I might make one! This is a pain point of Rust, having to implement traits on all the different reference types. 

If this doesn't make sense as to why it fixed it, or it's broken elsewhere now, I'm happy to dig more! 